### PR TITLE
chore: add pre-push hook for tests and build

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Pre-push hook - blokkeert push als tests of build falen
+# Kopieer naar: .husky/pre-push
+# Maak executable: chmod +x .husky/pre-push
+
+echo "🔍 Pre-push checks starten..."
+echo ""
+
+# Run tests
+echo "📋 Tests runnen..."
+npm run test
+if [ $? -ne 0 ]; then
+  echo ""
+  echo "❌ Tests gefaald! Push geblokkeerd."
+  echo "   Fix de tests en probeer opnieuw."
+  exit 1
+fi
+
+# Run build
+echo ""
+echo "🏗️  Build runnen..."
+npm run build
+if [ $? -ne 0 ]; then
+  echo ""
+  echo "❌ Build gefaald! Push geblokkeerd."
+  echo "   Fix de build errors en probeer opnieuw."
+  exit 1
+fi
+
+echo ""
+echo "✅ Alle pre-push checks geslaagd!"
+echo "   Push gaat door..."


### PR DESCRIPTION
## Summary
- Adds pre-push hook that runs `npm run test` and `npm run build`
- Blocks push if either fails, preventing broken code from reaching remote

Part of workflow improvements to prevent broken deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)