### PR TITLE
chore: Bump version to 1.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svenska-kat",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Swedish language learning web application with gamification",
   "type": "module",
   "scripts": {

--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -3,7 +3,7 @@
  */
 
 // App version - synced with package.json via Vite
-export const APP_VERSION = __APP_VERSION__ || '1.12.0';
+export const APP_VERSION = __APP_VERSION__ || '1.12.1';
 
 // Supabase configuration from environment variables
 export const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Svenska Kat PWA
-// Version 1.10.4 - WCAG Quick Wins + Privacy Toggle
+// Version 1.12.1 - TTS audio buttons in grammar sections
 
-const CACHE_VERSION = '1.10.4';
+const CACHE_VERSION = '1.12.1';
 const CACHE_NAME = `svenska-kat-v${CACHE_VERSION}`;
 const CDN_CACHE = `svenska-kat-cdn-v${CACHE_VERSION}`;
 


### PR DESCRIPTION
## Summary
- Syncs all version numbers to 1.12.1
- Triggers PWA update for users to get TTS grammar buttons (PR #74)

## Changes
- `package.json`: 1.12.0 → 1.12.1
- `src/js/utils/constants.js`: 1.12.0 → 1.12.1  
- `sw.js`: 1.10.4 → 1.12.1

## Note
SW was still at 1.10.4, causing PWA to not detect updates since then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)