### PR TITLE
fix: Improve speech recognition UX and Safari support

### DIFF
--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -179,6 +179,15 @@ export function hasSpeechRecognition() {
 }
 
 /**
+ * Check if current browser is Safari (macOS or iOS)
+ * @returns {boolean} Whether browser is Safari
+ */
+export function isSafari() {
+    const ua = navigator.userAgent;
+    return /^((?!chrome|android).)*safari/i.test(ua);
+}
+
+/**
  * Get the SpeechRecognition constructor
  * @returns {SpeechRecognition|null} SpeechRecognition constructor or null
  */


### PR DESCRIPTION
## Summary
Verbetert de spraakherkenning UX en voegt Safari-specifieke ondersteuning toe.

## Problemen opgelost

1. **UX: Spraakherkenning knop was verborgen**
   - Was: Knop verscheen pas NA opnemen
   - Nu: Knop is direct zichtbaar als aparte feature

2. **Bug: `markAudioListened is not a function`**
   - Ontbrekende methode toegevoegd (bestaande bug op main)

3. **Safari macOS: Betere error messages**
   - 10 seconden timeout voor Safari
   - Safari-specifieke foutmeldingen met instructies voor Dictation

## Bekende Safari beperkingen (NIET opgelost, platform limitaties)

| Feature | Safari macOS | Chrome/Firefox | iOS |
|---------|--------------|----------------|-----|
| Audio opname | ✅ | ✅ | ✅ |
| Audio playback (blob) | ❌ WebKit bug | ✅ | ✅ |
| Spraakherkenning | ❌ service-not-allowed | ✅ | ❌ |

Safari macOS spraakherkenning vereist:
- Dictation ingeschakeld in Systeemvoorkeuren > Toetsenbord > Dictation
- Zelfs dan kan het `service-not-allowed` geven (Apple beperking)

## Changes

| File | Change |
|------|--------|
| `src/js/views/PracticeView.js` | Spraakherkenning als aparte sectie |
| `src/js/app.js` | Safari timeout, betere errors, `markAudioListened()` |
| `src/js/utils/helpers.js` | Nieuwe `isSafari()` helper |

## Test plan
- [x] Lint passed
- [x] Tests passed
- [x] Build succeeded
- [x] Test op Safari macOS - errors gelogd, limitaties gedocumenteerd
- [ ] Test op Chrome
- [x] Test op iOS (fallback message)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)