### PR TITLE
feat: Simplify Daily Program - remove category selection (#83)

### DIFF
--- a/docs/blog/2024-12-04-ai-agents-als-team.md
+++ b/docs/blog/2024-12-04-ai-agents-als-team.md
@@ -1,0 +1,153 @@
+# AI agents als virtueel team: hoe ik samen met Claude mijn app ontwikkel
+
+*4 december 2024*
+
+Vandaag had ik een bijzondere ontwikkelsessie. Niet alleen programmeren, maar een complete productcyclus doorlopen - van onderzoek tot implementatie - met behulp van AI agents die elk hun eigen expertise inbrengen.
+
+## De situatie
+
+De ZweedsApp is een taal-leerapp die ik aan het bouwen ben. Na maanden van feature-toevoegingen was de app te complex geworden. Te veel klikken, te veel keuzes. Tijd om terug naar de basis te gaan.
+
+Maar waar begin je? En hoe zorg je dat je niet zomaar wat verandert, maar onderbouwde beslissingen neemt?
+
+## Het team
+
+Ik werk met Claude Code en heb een "team" van AI agents geconfigureerd. Elke agent heeft een eigen persoonlijkheid, expertise en werkwijze:
+
+| Agent | Naam | Expertise |
+|-------|------|-----------|
+| Product Owner | Tessa | Prioritering, scope, impact/effort analyse |
+| UX Designer | Veerle | User flows, wireframes, Hick's Law |
+| Frontend Developer | Anneke | JavaScript, PWA, implementatie |
+| Zweedstalige Eindredacteur | Vanya | Content audit, vertalingen |
+
+Deze agents zijn geen losse tools. Ze zijn gedocumenteerd in markdown bestanden met hun werkwijze, frameworks en output formats. Als ik een agent "inschakel", laadt Claude dat bestand en neemt die rol aan.
+
+## De sessie: van vraag tot feature
+
+### Stap 1: De vraag stellen
+
+Ik begon simpel:
+> "Issue #40 - 'Alle categorieën' optie. Is die nog relevant met de nieuwe dagelijkse oefeningen?"
+
+In plaats van direct te antwoorden, vroeg Claude: **"Wie van de agents kan dat beoordelen?"**
+
+Dat dwong mij om na te denken. Dit is geen technische vraag, maar een productvraag. Dus: **Tessa (PO)**.
+
+### Stap 2: Tessa doet impact/effort analyse
+
+Tessa analyseerde Issue #40 met haar framework:
+
+```
+IMPACT SCORE: 3/10 (met Daily Program erbij)
+EFFORT SCORE: 3/5
+PRIORITY SCORE: 2.0 → Backlog
+```
+
+Haar conclusie: "Daily Program lost 80% van de behoefte op. Defer naar M4."
+
+**Mijn rol**: Ik hoefde alleen "ok" te zeggen. De onderbouwing was helder.
+
+### Stap 3: Onderzoek doen (Issue #58)
+
+Tessa had al geprioriteerd: eerst Issue #58 - "Onderzoek Duolingo leerfunctionaliteit".
+
+Claude deed web research, las artikelen over Duolingo's UX, en vatte samen:
+
+- **Duolingo flow**: 2 klikken tot start
+- **Onze flow**: 4 klikken tot start
+- **Kernprincipe**: "App kiest, gebruiker doet"
+
+### Stap 4: Scope bepalen
+
+Weer de vraag: **"Wie bepaalt de scope?"**
+
+Terug naar Tessa. Ze presenteerde 4 opties met scores:
+
+| Optie | Score |
+|-------|-------|
+| A: Verwijder categoriekeuze | 7.0 🔴 |
+| B: Voeg streak toe | 4.0 🟠 |
+| C: Lineair pad | 3.2 🟠 |
+| D: Verwijder exercise keuze | 5.0 🟠 |
+
+**Mijn keuze**: "Focus op A" - hoogste score, laagste effort.
+
+### Stap 5: UX ontwerp
+
+Nu **Veerle (UX Designer)**. Ze ontwierp de nieuwe flow:
+
+```
+[Home]
+└─ Tap "Dagelijkse Oefening"
+   └─ → [Daily Screen]
+      └─ Shows: "5 zinnen uit mix van categorieën"
+         └─ Tap "Start"
+            └─ → [Practice]
+```
+
+Plus een wireframe met category preview en START knop.
+
+**Mijn feedback**: "Geen modals toch?"
+
+Veerle paste direct aan. De "Bekijk alle items" link verdween.
+
+### Stap 6: Implementatie
+
+Tot slot **Anneke (Frontend Developer)**. Ze:
+1. Maakte een nieuwe `DailyView.js`
+2. Voegde de DAILY tab toe
+3. Implementeerde `startDailyFromBeginning()`
+4. Paste de HomeView aan
+
+Build + tests: ✅
+
+## Wat ik leerde
+
+### 1. Agents dwingen proces af
+
+Door te vragen "wie kan dit beoordelen?" voorkom je dat je direct in de code duikt. Eerst denken, dan doen.
+
+### 2. Frameworks maken beslissingen traceerbaar
+
+Tessa's Impact/Effort score is niet magisch, maar het dwingt je om na te denken over *waarom* je iets doet. "Score 7.0" is beter dan "voelt goed".
+
+### 3. De opdrachtgever blijft de opdrachtgever
+
+Ik zeg "ok" of "nee". De agents adviseren, ik beslis. Dat voelt goed.
+
+### 4. Context wisselen kost geen tijd
+
+In een menselijk team zou je een meeting moeten plannen om van PO naar UX naar Dev te gaan. Hier is het een kwestie van "laad het volgende bestand".
+
+## De resultaten
+
+In één sessie:
+- Issue #40 → M4 (deferred)
+- Issue #58 → gesloten (onderzoek compleet)
+- Issue #83 → aangemaakt + geïmplementeerd
+- Issue #38 → content audit compleet (250 zinnen gecheckt, 11 correcties)
+- M1: Clarity → gesloten
+
+En een blogpost geschreven door de agents zelf.
+
+## Hoe je dit zelf kunt opzetten
+
+1. **Definieer je agents** in markdown bestanden met:
+   - Naam en persoonlijkheid
+   - Expertise en werkwijze
+   - Frameworks en templates
+   - Output format
+
+2. **Laad de juiste agent** voor de taak:
+   - Productvragen → PO
+   - UX vragen → UX Designer
+   - Technische vragen → Developer
+
+3. **Blijf de beslisser**. AI adviseert, jij beslist.
+
+4. **Documenteer alles**. Issues, commits, learnings. Niet alleen voor de AI, maar voor jezelf over 3 maanden.
+
+---
+
+*Dit artikel is geschreven tijdens een ontwikkelsessie met Claude Code en de agents Tessa, Veerle, Vanya en Anneke.*

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -45,6 +45,7 @@ import {
     renderSetup,
     toggleSignUp,
     renderHome,
+    renderDaily,
     renderCategories,
     renderSettings,
     renderPractice,
@@ -638,6 +639,28 @@ export class SwedishApp {
         this.render();
     }
 
+    /**
+     * Start daily program from first incomplete item
+     * Called from the new simplified Daily View
+     */
+    startDailyFromBeginning() {
+        const phrases = this.state.dailyPhrases || [];
+        const completedPhrases = this.state.dailyCompletedPhrases || [];
+
+        // Find first incomplete item
+        const firstIncompleteIndex = phrases.findIndex(
+            p => !completedPhrases.includes(`${p.categoryId}-${p.id}`)
+        );
+
+        // If all done, stay on daily view
+        if (firstIncompleteIndex === -1) {
+            return;
+        }
+
+        // Start from first incomplete
+        this.startDailyPhrase(firstIncompleteIndex);
+    }
+
     // =====================
     // Navigation
     // =====================
@@ -882,6 +905,8 @@ export class SwedishApp {
         switch (this.state.currentTab) {
             case TABS.HOME:
                 return renderHome(this.state);
+            case TABS.DAILY:
+                return renderDaily(this.state);
             case TABS.CATEGORIES:
                 return renderCategories(this.state, filterFn);
             case TABS.PRACTICE:
@@ -904,6 +929,7 @@ export class SwedishApp {
     renderAppHeader() {
         const tabTitles = {
             [TABS.HOME]: 'Svenska Kat',
+            [TABS.DAILY]: 'Dagelijks',
             [TABS.CATEGORIES]: 'Categorieën',
             [TABS.PRACTICE]: 'Uitspraak',
             [TABS.WRITING]: 'Schrijven',

--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -93,6 +93,7 @@ export const DIFFICULTY_FILTERS = {
 // Tab names
 export const TABS = {
     HOME: 'home',
+    DAILY: 'daily',
     CATEGORIES: 'categories',
     PRACTICE: 'practice',
     FLASHCARDS: 'flashcards',

--- a/src/js/views/DailyView.js
+++ b/src/js/views/DailyView.js
@@ -1,0 +1,154 @@
+/**
+ * Daily View
+ * Simplified daily program screen with auto-selected phrases
+ * Design by Veerle (UX Designer) - Issue #83
+ */
+
+import { escapeHtml } from '../utils/helpers.js';
+
+/**
+ * Get greeting based on time of day
+ * @returns {string} Greeting text
+ */
+function getGreeting() {
+    const hour = new Date().getHours();
+    if (hour < 12) {
+        return 'Goedemorgen!';
+    }
+    if (hour < 18) {
+        return 'Goedemiddag!';
+    }
+    return 'Goedenavond!';
+}
+
+/**
+ * Get category summary from daily phrases
+ * @param {array} dailyPhrases - Today's phrases
+ * @returns {object} Category counts
+ */
+function getCategorySummary(dailyPhrases) {
+    const summary = {};
+    dailyPhrases.forEach(phrase => {
+        const name = phrase.categoryName || 'Onbekend';
+        summary[name] = (summary[name] || 0) + 1;
+    });
+    return summary;
+}
+
+/**
+ * Render Daily View
+ * @param {object} state - App state
+ * @returns {string} HTML string
+ */
+export function renderDaily(state) {
+    const phrases = state.dailyPhrases || [];
+    const completedPhrases = state.dailyCompletedPhrases || [];
+
+    const completedCount = phrases.filter(p =>
+        completedPhrases.includes(`${p.categoryId}-${p.id}`)
+    ).length;
+    const total = phrases.length;
+    const progressPercent = total > 0 ? (completedCount / total) * 100 : 0;
+    const allDone = completedCount === total && total > 0;
+
+    // Get category summary for preview
+    const categorySummary = getCategorySummary(phrases);
+
+    // Find first incomplete item index
+    const firstIncompleteIndex = phrases.findIndex(
+        p => !completedPhrases.includes(`${p.categoryId}-${p.id}`)
+    );
+
+    return `
+        <div class="space-y-6 animate-slideUp">
+            <!-- Greeting -->
+            <div class="text-center pt-4">
+                <p class="text-3xl mb-2">${getGreeting().includes('morgen') ? '🌅' : getGreeting().includes('middag') ? '☀️' : '🌙'}</p>
+                <h2 class="text-2xl font-bold text-gray-800">${getGreeting()}</h2>
+            </div>
+
+            <!-- Progress Card -->
+            <div class="bg-white rounded-2xl p-6 card-shadow">
+                <div class="text-center mb-4">
+                    <p class="text-lg text-gray-600 mb-1">Vandaag</p>
+                    <p class="text-4xl font-bold" style="color: var(--scandi-blue);">
+                        ${completedCount}/${total}
+                    </p>
+                    <p class="text-sm text-gray-500 mt-1">oefeningen voltooid</p>
+                </div>
+
+                <!-- Progress dots -->
+                <div class="flex justify-center gap-2 mb-4">
+                    ${phrases
+                        .map((p, i) => {
+                            const isCompleted = completedPhrases.includes(
+                                `${p.categoryId}-${p.id}`
+                            );
+                            return `<div class="w-3 h-3 rounded-full transition-all ${isCompleted ? 'bg-green-500' : 'bg-gray-200'}"></div>`;
+                        })
+                        .join('')}
+                </div>
+
+                <!-- Progress bar -->
+                <div class="bg-gray-200 rounded-full h-2 overflow-hidden">
+                    <div class="h-2 rounded-full transition-all duration-500"
+                         style="width: ${progressPercent}%; background: linear-gradient(90deg, var(--scandi-blue) 0%, #5B9BD5 100%);"></div>
+                </div>
+            </div>
+
+            <!-- Category Preview -->
+            <div class="bg-gray-50 rounded-xl p-4">
+                <p class="text-sm font-medium text-gray-600 mb-2">Mix van categorieën:</p>
+                <div class="flex flex-wrap gap-2">
+                    ${Object.entries(categorySummary)
+                        .map(
+                            ([name, count]) => `
+                        <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm bg-white border border-gray-200">
+                            <span class="font-medium text-gray-700">${escapeHtml(name)}</span>
+                            <span class="text-gray-400">(${count})</span>
+                        </span>
+                    `
+                        )
+                        .join('')}
+                </div>
+            </div>
+
+            <!-- Start Button -->
+            ${
+                allDone
+                    ? `
+                <div class="text-center py-8">
+                    <div class="w-20 h-20 mx-auto rounded-full bg-green-100 flex items-center justify-center mb-4">
+                        <i class="fas fa-check text-4xl text-green-500"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Geweldig gedaan!</h3>
+                    <p class="text-gray-600 mb-4">Je hebt alle oefeningen voor vandaag voltooid.</p>
+                    <button onclick="app.setTab('home')"
+                            class="px-6 py-3 rounded-xl font-semibold text-gray-700 bg-gray-100 hover:bg-gray-200 transition-all">
+                        Terug naar Home
+                    </button>
+                </div>
+            `
+                    : `
+                <button onclick="app.startDailyFromBeginning()"
+                        class="w-full py-5 rounded-2xl font-bold text-xl text-white transition-all transform hover:scale-[1.02] active:scale-[0.98] card-shadow"
+                        style="background: linear-gradient(135deg, var(--scandi-blue) 0%, #2F5F8A 100%);">
+                    <i class="fas fa-play mr-2"></i>
+                    Start
+                </button>
+
+                ${
+                    completedCount > 0
+                        ? `
+                    <p class="text-center text-sm text-gray-500 mt-2">
+                        Ga verder waar je gebleven was
+                    </p>
+                `
+                        : ''
+                }
+            `
+            }
+
+        </div>
+    `;
+}

--- a/src/js/views/HomeView.js
+++ b/src/js/views/HomeView.js
@@ -58,7 +58,7 @@ function renderDailyProgram(dailyPhrases, completedPhrases) {
     });
 
     return `
-        <button id="daily-program" onclick="app.openDailyProgramModal()"
+        <button id="daily-program" onclick="app.setTab('daily')"
                 class="w-full rounded-2xl p-6 card-shadow card-hover text-left border-3 transition-all"
                 style="background: linear-gradient(135deg, rgba(91, 155, 213, 0.15) 0%, rgba(74, 127, 168, 0.08) 100%); border: 3px solid var(--scandi-blue);">
             <div class="flex items-center justify-between">

--- a/src/js/views/index.js
+++ b/src/js/views/index.js
@@ -7,6 +7,7 @@ import { renderStreakCalendar } from '../components/StreakCalendar.js';
 
 export { renderLogin, renderSetup, toggleSignUp } from './LoginView.js';
 export { renderHome } from './HomeView.js';
+export { renderDaily } from './DailyView.js';
 export { renderCategories } from './CategoriesView.js';
 export { renderSettings } from './SettingsView.js';
 export { renderPractice } from './PracticeView.js';


### PR DESCRIPTION
## Summary
- New simplified Daily screen replaces modal with category selection
- Reduced clicks from 4 to 2 (Home → Daily → Start)
- App auto-selects mix of phrases, user just clicks START
- Category preview shows what's coming (transparency without choice overload)

## Based on
- Issue #58: Duolingo UX research
- Tessa (PO): Impact/Effort analysis - Score 7.0 (highest priority)
- Veerle (UX): Flow design and wireframe

## Changes
- New `DailyView.js` with simplified flow
- `HomeView.js`: Daily card now navigates to Daily tab (not modal)
- `app.js`: Added `startDailyFromBeginning()` method
- `constants.js`: Added DAILY tab

## Screenshots
The new Daily screen shows:
- Greeting based on time of day
- Progress (X/10 completed)
- Progress dots for each item
- Category preview chips
- Big START button

## Test plan
- [x] npm run lint passed
- [x] npm run test passed  
- [x] npm run build passed
- [x] Handmatig getest in browser
  - [x] Home → Daily card opens Daily screen
  - [x] Category preview shows correctly
  - [x] START begins at first incomplete item
  - [x] Progress updates after completing items
  - [x] "Geweldig gedaan!" shows when all complete

## Known issues
- #84: Gefeliciteerd modal moeilijk weg te klikken (separate issue)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)