### PR TITLE
fix: Login autocomplete vulde verkeerd in (#93)

### DIFF
--- a/src/js/views/LoginView.js
+++ b/src/js/views/LoginView.js
@@ -19,7 +19,7 @@ export function renderLogin() {
                 <form class="space-y-4" action="#" method="post" onsubmit="event.preventDefault(); app.handleLogin();">
                     <div>
                         <label class="block text-sm font-semibold text-gray-700 mb-2" for="email">Email</label>
-                        <input type="email" id="email" name="email" autocomplete="username" placeholder="jouw@email.com"
+                        <input type="email" id="email" name="email" autocomplete="email" placeholder="jouw@email.com"
                                required
                                class="w-full p-4 border-2 border-gray-200 rounded-xl font-medium">
                     </div>
@@ -139,7 +139,7 @@ export function toggleSignUp(event) {
     } else {
         // Switch to login mode
         displayNameField.style.display = 'none';
-        emailField.setAttribute('autocomplete', 'username');
+        emailField.setAttribute('autocomplete', 'email');
         passwordField.setAttribute('autocomplete', 'current-password');
         displayNameInput.removeAttribute('required');
         button.innerHTML = '<i class="fas fa-user-plus mr-2"></i>Nog geen account? Registreer';


### PR DESCRIPTION
## Summary
- Changed `autocomplete="username"` to `autocomplete="email"` on email input
- Browser was filling password into email field due to `username` autocomplete hint

## Test plan
- [ ] Open login pagina
- [ ] Laat browser autocomplete zijn werk doen
- [ ] Email veld krijgt email, wachtwoord veld krijgt wachtwoord

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)