### PR TITLE
fix: sync daily program progress between devices via Supabase

### DIFF
--- a/src/js/services/data.js
+++ b/src/js/services/data.js
@@ -34,7 +34,10 @@ export function getDefaultStats() {
             'cats',
             'august',
             'shopping'
-        ]
+        ],
+        // Daily program sync (for cross-device sync)
+        dailyProgramDate: null, // ISO date string (YYYY-MM-DD)
+        dailyCompletedPhrases: [] // Phrase IDs completed today
     };
 }
 


### PR DESCRIPTION
## Summary
- Fix voor issue #102: Daily oefeningen status wordt niet gesynct tussen devices
- Daily program voortgang (welke zinnen vandaag afgerond) wordt nu opgeslagen in Supabase
- Bij inloggen op ander device wordt de voortgang automatisch hersteld

## Technische wijzigingen
- `dailyProgramDate` en `dailyCompletedPhrases` toegevoegd aan stats object in `data.js`
- `loadUserData()` synct daily state van Supabase naar localStorage
- `saveUserData()` includeert daily state voor cross-device sync
- Alle locaties waar daily completion wordt opgeslagen nu consistent

## Test plan
- [ ] Log in op device A, markeer enkele dagelijkse zinnen als compleet
- [ ] Log in op device B, verificeer dat dezelfde zinnen als compleet getoond worden
- [ ] Verifieer dat de sync alleen geldt voor dezelfde dag (nieuwe dag = verse start)

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)