### PR TITLE
fix: ensure longestStreak is always up to date

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -406,25 +406,22 @@ export class SwedishApp {
             // First practice ever - start streak
             this.state.stats.streak = 1;
             this.state.stats.lastPracticeDate = today;
-            this.updateLongestStreak();
-            return;
-        }
-
-        if (isToday(lastDate)) {
+        } else if (isToday(lastDate)) {
             // Already practiced today - streak unchanged
-            return;
-        }
-
-        if (isYesterday(lastDate)) {
+            // Continue to updateLongestStreak() to ensure longestStreak is correct
+        } else if (isYesterday(lastDate)) {
             // Streak continues - increment
             this.state.stats.streak = (this.state.stats.streak || 0) + 1;
             this.state.stats.lastPracticeDate = today;
-            this.updateLongestStreak();
         } else {
             // Streak broken - reset to 1 (today counts)
             this.state.stats.streak = 1;
             this.state.stats.lastPracticeDate = today;
         }
+
+        // Always update longest streak to ensure it's never less than current streak
+        // This fixes edge cases where longestStreak could get out of sync
+        this.updateLongestStreak();
     }
 
     /**


### PR DESCRIPTION
## Summary
- Fixes bug where longestStreak showed 6 while current streak was 7
- Ensures longestStreak is always updated, regardless of which code path is taken in checkStreak()

## Root Cause
`updateLongestStreak()` was only called in some branches of `checkStreak()`. When the user had already practiced today (`isToday` branch), the function returned early without calling `updateLongestStreak()`.

## Changes
- Refactored `checkStreak()` to always call `updateLongestStreak()` at the end
- Simplified control flow using if-else instead of early returns

## Test plan
- [ ] Verify longestStreak updates when streak increases
- [ ] Verify longestStreak stays correct after multiple practices on same day
- [ ] Verify longestStreak is preserved when streak resets

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)