### PR TITLE
feat(vocabulary): add tier-based vocabulary system for grammar exercises

### DIFF
--- a/.claude/agents/_agents
+++ b/.claude/agents/_agents
@@ -1,0 +1,1 @@
+/Users/monique/Projecten/_agents

--- a/.claude/knowledge
+++ b/.claude/knowledge
@@ -1,0 +1,1 @@
+/Users/monique/Projecten/_agents/_knowledge

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Monique Dubbelman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,98 @@
+# Versiebeheer
+
+Dit document beschrijft hoe versies worden beheerd in Svenska Kat.
+
+## Semantic Versioning
+
+We volgen [Semantic Versioning](https://semver.org/):
+
+```
+MAJOR.MINOR.PATCH
+1.12.0
+```
+
+- **MAJOR**: Breaking changes (niet backward compatible)
+- **MINOR**: Nieuwe features (backward compatible)
+- **PATCH**: Bug fixes (backward compatible)
+
+## Wanneer ophogen?
+
+### PATCH verhogen (1.12.0 → 1.12.1)
+- Bug fixes
+- Kleine styling aanpassingen
+- Performance verbeteringen
+- Typo's en tekst correcties
+
+### MINOR verhogen (1.12.0 → 1.13.0)
+- Nieuwe features
+- Nieuwe oefenvormen
+- Uitbreiding grammatica sectie
+- Nieuwe categorieën
+- Significante UX verbeteringen
+
+### MAJOR verhogen (1.x.x → 2.0.0)
+- Database schema wijzigingen
+- Breaking API changes
+- Complete redesign
+- Niet backward compatible met vorige data
+
+## Workflow voor releases
+
+### 1. Dagelijkse ontwikkeling
+Werk op feature branches, merge naar main. Versie blijft gelijk totdat we releasen.
+
+### 2. Bij release (wekelijks of bij significante features)
+
+```bash
+# 1. Update package.json versie
+npm version minor  # of patch/major
+
+# 2. Update CHANGELOG.md met nieuwe versie
+# Voeg sectie toe bovenaan met datum en changes
+
+# 3. Commit en push
+git add .
+git commit -m "chore: release v1.13.0"
+git push
+```
+
+### 3. Automatische versie propagatie
+- `package.json` is de "source of truth"
+- Vite injecteert versie via `__APP_VERSION__`
+- App toont versie in Settings
+
+## Update notificaties voor gebruikers
+
+De app toont automatisch een notificatie wanneer:
+1. De Service Worker een nieuwe versie detecteert
+2. De gebruiker de app opnieuw opent na een update
+
+### Wat de gebruiker ziet
+- "Nieuwe versie beschikbaar!" banner
+- "Update Nu" knop om te verversen
+- Versienummer in Settings pagina
+
+### Release Notes
+Bij significante updates kan een "Wat is nieuw?" modal worden getoond:
+- Wordt getriggerd door `lastSeenVersion !== APP_VERSION`
+- Toont highlights uit CHANGELOG
+- Gebruiker kan later terugkijken in Settings
+
+## Huidige versie
+
+Zie `package.json` voor de huidige versie:
+
+```bash
+cat package.json | grep '"version"'
+```
+
+Of in de app: Settings → Versie
+
+## Checklist voor releases
+
+- [ ] Alle tests slagen (`npm run test`)
+- [ ] Build slaagt (`npm run build`)
+- [ ] CHANGELOG.md bijgewerkt met nieuwe versie
+- [ ] package.json versie opgehoogd
+- [ ] Commit message: `chore: release vX.Y.Z`
+- [ ] Tag aangemaakt (optioneel): `git tag v1.13.0`

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -637,13 +637,16 @@ export class SwedishApp {
             exerciseType: index % 2 === 0 ? 'practice' : 'writing'
         }));
 
-        // Get 2 grammar exercises
-        const grammarItems = getRandomGrammarExercises(2, difficultyFilter).map(exercise => ({
-            ...exercise,
-            exerciseType: 'grammar',
-            categoryId: 'grammar',
-            categoryName: 'Grammatica'
-        }));
+        // Get 2 grammar exercises (filtered by unlocked vocabulary)
+        const completedExercises = this.state.completedPhrases?.length || 0;
+        const grammarItems = getRandomGrammarExercises(2, difficultyFilter, completedExercises).map(
+            exercise => ({
+                ...exercise,
+                exerciseType: 'grammar',
+                categoryId: 'grammar',
+                categoryName: 'Grammatica'
+            })
+        );
 
         // Combine: 8 phrases + 2 grammar = 10 items total
         // Interleave grammar at positions 4 and 8 for variety

--- a/src/js/data/grammarExercises.js
+++ b/src/js/data/grammarExercises.js
@@ -9,6 +9,8 @@
  * - translation: Translate a word/phrase
  */
 
+import { extractVerbIdFromPrompt, getUnlockedVerbIds } from './vocabulary.js';
+
 export const grammarExercises = {
     // Werkwoord conjugatie oefeningen
     conjugation: [
@@ -818,12 +820,26 @@ export const grammarExercises = {
  * Get random grammar exercises for daily program
  * @param {number} count - Number of exercises to return
  * @param {string} difficulty - Filter by difficulty (easy, medium, hard)
+ * @param {number} completedExercises - Number of completed exercises (for vocabulary filtering)
  * @returns {Array} Array of grammar exercises
  */
-export function getRandomGrammarExercises(count = 2, difficulty = null) {
-    // Collect all exercises
+export function getRandomGrammarExercises(count = 2, difficulty = null, completedExercises = 0) {
+    // Get unlocked verb IDs based on progress
+    const unlockedVerbIds = getUnlockedVerbIds(completedExercises);
+
+    // Filter conjugation exercises to only include unlocked verbs
+    const filteredConjugation = grammarExercises.conjugation.filter(exercise => {
+        const verbId = extractVerbIdFromPrompt(exercise.prompt);
+        // If we can't extract verb ID, include the exercise (safe default)
+        if (!verbId) {
+            return true;
+        }
+        return unlockedVerbIds.includes(verbId);
+    });
+
+    // Collect all exercises (with filtered conjugation)
     let allExercises = [
-        ...grammarExercises.conjugation,
+        ...filteredConjugation,
         ...grammarExercises.pronoun,
         ...grammarExercises.article,
         ...grammarExercises.adjective,

--- a/src/js/data/vocabulary.js
+++ b/src/js/data/vocabulary.js
@@ -1,0 +1,327 @@
+/**
+ * Vocabulary System
+ * Tier-based vocabulary for progressive learning
+ *
+ * Based on Learning Specialist (Lotte) recommendations:
+ * - Explicit Before Implicit (EBI): words introduced before exercises
+ * - Tier system: unlock vocabulary progressively
+ * - Difficulty scoring based on verb group and frequency
+ *
+ * Verb Groups (Swedish):
+ * - Group 1 (-ar): Regular, stam + ar (tala → talar)
+ * - Group 2 (-er): Regular, stam + er (läsa → läser)
+ * - Group 3 (kort): Short verbs, stam + r (bo → bor)
+ * - Group 4 (onregelmatig): Irregular (vara → är, ha → har)
+ *
+ * Difficulty Score:
+ * - Group 1: +5 (easiest pattern)
+ * - Group 2: +10
+ * - Group 3: +15 (vowel changes common)
+ * - Group 4: +30 (irregular, must memorize)
+ * - Low frequency: +15
+ *
+ * Score → Level:
+ * - ≤15 = Easy
+ * - ≤35 = Medium
+ * - >35 = Hard
+ */
+
+/**
+ * Verb vocabulary with conjugation data
+ * Each verb includes: infinitive, present, past, group, dutch translation
+ */
+export const verbs = {
+    // === TIER 1: Absolute Basics ===
+    // Unlocked from start - essential verbs everyone needs
+    tier1: [
+        {
+            id: 'vara',
+            infinitive: 'att vara',
+            present: 'är',
+            past: 'var',
+            supine: 'varit',
+            group: 4,
+            dutch: 'zijn',
+            difficulty: 'easy', // Despite being irregular, it's so common
+            frequency: 'high'
+        },
+        {
+            id: 'ha',
+            infinitive: 'att ha',
+            present: 'har',
+            past: 'hade',
+            supine: 'haft',
+            group: 4,
+            dutch: 'hebben',
+            difficulty: 'easy',
+            frequency: 'high'
+        },
+        {
+            id: 'bo',
+            infinitive: 'att bo',
+            present: 'bor',
+            past: 'bodde',
+            supine: 'bott',
+            group: 3,
+            dutch: 'wonen',
+            difficulty: 'easy',
+            frequency: 'high'
+        },
+        {
+            id: 'tala',
+            infinitive: 'att tala',
+            present: 'talar',
+            past: 'talade',
+            supine: 'talat',
+            group: 1,
+            dutch: 'praten',
+            difficulty: 'easy',
+            frequency: 'high'
+        }
+    ],
+
+    // === TIER 2: Daily Essentials ===
+    // Unlocked after 20 completed exercises
+    tier2: [
+        {
+            id: 'lasa',
+            infinitive: 'att läsa',
+            present: 'läser',
+            past: 'läste',
+            supine: 'läst',
+            group: 2,
+            dutch: 'lezen',
+            difficulty: 'easy',
+            frequency: 'high'
+        },
+        {
+            id: 'skriva',
+            infinitive: 'att skriva',
+            present: 'skriver',
+            past: 'skrev',
+            supine: 'skrivit',
+            group: 4, // Irregular past tense
+            dutch: 'schrijven',
+            difficulty: 'medium',
+            frequency: 'high'
+        },
+        {
+            id: 'ata',
+            infinitive: 'att äta',
+            present: 'äter',
+            past: 'åt',
+            supine: 'ätit',
+            group: 4, // Irregular past tense
+            dutch: 'eten',
+            difficulty: 'medium',
+            frequency: 'high'
+        },
+        {
+            id: 'arbeta',
+            infinitive: 'att arbeta',
+            present: 'arbetar',
+            past: 'arbetade',
+            supine: 'arbetat',
+            group: 1,
+            dutch: 'werken',
+            difficulty: 'easy',
+            frequency: 'high'
+        },
+        {
+            id: 'fraga',
+            infinitive: 'att fråga',
+            present: 'frågar',
+            past: 'frågade',
+            supine: 'frågat',
+            group: 1,
+            dutch: 'vragen',
+            difficulty: 'easy',
+            frequency: 'high'
+        },
+        {
+            id: 'tro',
+            infinitive: 'att tro',
+            present: 'tror',
+            past: 'trodde',
+            supine: 'trott',
+            group: 3,
+            dutch: 'geloven',
+            difficulty: 'easy',
+            frequency: 'medium'
+        }
+    ],
+
+    // === TIER 3: Expanding Vocabulary ===
+    // Unlocked after 50 completed exercises
+    tier3: [
+        {
+            id: 'kopa',
+            infinitive: 'att köpa',
+            present: 'köper',
+            past: 'köpte',
+            supine: 'köpt',
+            group: 2,
+            dutch: 'kopen',
+            difficulty: 'medium',
+            frequency: 'high'
+        },
+        {
+            id: 'se',
+            infinitive: 'att se',
+            present: 'ser',
+            past: 'såg',
+            supine: 'sett',
+            group: 4,
+            dutch: 'zien',
+            difficulty: 'medium',
+            frequency: 'high'
+        },
+        {
+            id: 'komma',
+            infinitive: 'att komma',
+            present: 'kommer',
+            past: 'kom',
+            supine: 'kommit',
+            group: 4,
+            dutch: 'komen',
+            difficulty: 'medium',
+            frequency: 'high'
+        },
+        {
+            id: 'ga',
+            infinitive: 'att gå',
+            present: 'går',
+            past: 'gick',
+            supine: 'gått',
+            group: 4,
+            dutch: 'gaan',
+            difficulty: 'medium',
+            frequency: 'high'
+        },
+        {
+            id: 'stanna',
+            infinitive: 'att stanna',
+            present: 'stannar',
+            past: 'stannade',
+            supine: 'stannat',
+            group: 1,
+            dutch: 'blijven',
+            difficulty: 'easy',
+            frequency: 'medium'
+        }
+    ]
+};
+
+/**
+ * Tier thresholds - exercises needed to unlock each tier
+ */
+export const tierThresholds = {
+    1: 0, // Available from start
+    2: 20, // After 20 exercises
+    3: 50 // After 50 exercises
+};
+
+/**
+ * Get all verbs up to and including a specific tier
+ * @param {number} maxTier - Maximum tier to include (1, 2, or 3)
+ * @returns {Array} Array of verb objects
+ */
+export function getVerbsUpToTier(maxTier) {
+    const result = [];
+    for (let tier = 1; tier <= maxTier; tier++) {
+        const tierKey = `tier${tier}`;
+        if (verbs[tierKey]) {
+            result.push(...verbs[tierKey]);
+        }
+    }
+    return result;
+}
+
+/**
+ * Get the tier level based on completed exercises
+ * @param {number} completedExercises - Number of completed exercises
+ * @returns {number} Current tier level (1, 2, or 3)
+ */
+export function getTierForProgress(completedExercises) {
+    if (completedExercises >= tierThresholds[3]) {
+        return 3;
+    }
+    if (completedExercises >= tierThresholds[2]) {
+        return 2;
+    }
+    return 1;
+}
+
+/**
+ * Get all unlocked verb IDs based on progress
+ * @param {number} completedExercises - Number of completed exercises
+ * @returns {Array<string>} Array of unlocked verb IDs
+ */
+export function getUnlockedVerbIds(completedExercises) {
+    const tier = getTierForProgress(completedExercises);
+    const unlockedVerbs = getVerbsUpToTier(tier);
+    return unlockedVerbs.map(v => v.id);
+}
+
+/**
+ * Check if a verb is unlocked
+ * @param {string} verbId - Verb ID to check
+ * @param {number} completedExercises - Number of completed exercises
+ * @returns {boolean} Whether the verb is unlocked
+ */
+export function isVerbUnlocked(verbId, completedExercises) {
+    const unlockedIds = getUnlockedVerbIds(completedExercises);
+    return unlockedIds.includes(verbId);
+}
+
+/**
+ * Get verb by ID
+ * @param {string} verbId - Verb ID
+ * @returns {object|null} Verb object or null if not found
+ */
+export function getVerbById(verbId) {
+    for (const tierKey of Object.keys(verbs)) {
+        const verb = verbs[tierKey].find(v => v.id === verbId);
+        if (verb) {
+            return verb;
+        }
+    }
+    return null;
+}
+
+/**
+ * Extract verb ID from exercise prompt
+ * Matches patterns like "(att tala)" or "(att läsa)"
+ * @param {string} prompt - Exercise prompt
+ * @returns {string|null} Verb ID or null if not found
+ */
+export function extractVerbIdFromPrompt(prompt) {
+    // Use character class that includes Swedish letters å, ä, ö
+    const match = prompt.match(/\(att\s+([\wåäöÅÄÖ]+)\)/i);
+    if (!match) {
+        return null;
+    }
+
+    const infinitive = match[1].toLowerCase();
+
+    // Map infinitive to verb ID (handling special characters)
+    const infinitiveToId = {
+        vara: 'vara',
+        ha: 'ha',
+        bo: 'bo',
+        tala: 'tala',
+        läsa: 'lasa',
+        skriva: 'skriva',
+        äta: 'ata',
+        arbeta: 'arbeta',
+        fråga: 'fraga',
+        tro: 'tro',
+        köpa: 'kopa',
+        se: 'se',
+        komma: 'komma',
+        gå: 'ga',
+        stanna: 'stanna'
+    };
+
+    return infinitiveToId[infinitive] || null;
+}


### PR DESCRIPTION
## Summary

Phase 1 implementation of issue #97 - Progressive vocabulary learning system.

### Changes
- **New `vocabulary.js`** with tier-based verb organization:
  - Tier 1 (0 phrases): vara, ha, bo, tala
  - Tier 2 (20+ phrases): + läsa, skriva, äta, arbeta, fråga, tro  
  - Tier 3 (50+ phrases): + köpa, se, komma, gå, stanna

- **Filter grammar exercises** based on unlocked vocabulary
- **Fix Swedish character regex** (å, ä, ö) in verb extraction

### Pedagogical Principle
Follows **Explicit Before Implicit (EBI)**: users only see conjugation exercises for verbs they have unlocked through practice.

## Test plan
- [x] `npm run lint` passed
- [x] `npm run test` passed  
- [x] `npm run build` passed
- [x] Tested tier filtering locally via browser console:
  - Tier 1: 7 conjugation exercises
  - Tier 2: 14 conjugation exercises
  - Tier 3: 20 conjugation exercises

Closes phase 1 of #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)